### PR TITLE
Fix null ref exceptions

### DIFF
--- a/UMI3D-BROWSER/Assets/Dependencies/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/PropertyList.cs
+++ b/UMI3D-BROWSER/Assets/Dependencies/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/PropertyList.cs
@@ -90,7 +90,7 @@ namespace umi3d.cdk
                         else
                             return false;
 
-                        OnValueRemoved(index);
+                        OnValueRemoved?.Invoke(index);
 
                         OnCollectionUpdated?.Invoke(this);
                         return true;
@@ -120,7 +120,6 @@ namespace umi3d.cdk
 
         public bool SetEntity(SetUMI3DPropertyData data)
         {
-            UnityEngine.Debug.Log($"SetEntity {data.property}");
             switch (data.property)
             {
                 case SetEntityListAddPropertyDto add:
@@ -173,7 +172,6 @@ namespace umi3d.cdk
 
         public void SetList(IEnumerable<S> values)
         {
-            UnityEngine.Debug.Log($"Set list {values.Count()}");
             this.Clear();
             this.AddRange(values.Select(v => Converter(v)));
         }

--- a/UMI3D-BROWSER/Assets/New UI/01-Scripts/UI/InGame/Tablet/Social/PrimaryUserActionIcon.cs
+++ b/UMI3D-BROWSER/Assets/New UI/01-Scripts/UI/InGame/Tablet/Social/PrimaryUserActionIcon.cs
@@ -111,10 +111,15 @@ namespace umi3d.browserRuntime.ui.inGame.tablet.social
 
         static protected async Task<Sprite> LoadIcon(UserActionDto dto)
         {
+            if (dto?.icon2D?.variants == null)
+                return null;
+
             Sprite icon;
             try
             {
                 var iconResourceFile = UMI3DEnvironmentLoader.AbstractParameters.ChooseVariant(dto.icon2D.variants);
+                if (iconResourceFile == null)
+                    return null;
                 IResourcesLoader loader = UMI3DEnvironmentLoader.AbstractParameters.SelectLoader(iconResourceFile.extension);
                 Texture2D texture = (Texture2D)await UMI3DResourcesManager.LoadFile(dto.id, iconResourceFile, loader);
                 icon = Sprite.Create(texture, new Rect(0.0f, 0.0f, texture.width, texture.height), new Vector2(0.5f, 0.5f), 100.0f);


### PR DESCRIPTION
An event was called without null check
SocialElement was trying to load sprite event if there was no variant.