### PR TITLE
Application Version

### DIFF
--- a/UMI3D-BROWSER/Assets/Editor/BuildTool/Helper/BuildToolHelper.cs
+++ b/UMI3D-BROWSER/Assets/Editor/BuildTool/Helper/BuildToolHelper.cs
@@ -110,6 +110,29 @@ namespace umi3d.browserEditor.BuildTool
             return path;
         }
 
+        /// <summary>
+        /// Set the Application version.
+        /// </summary>
+        /// <param name="target"></param>
+        /// <param name="newVersion"></param>
+        /// <param name="sdkVersion"></param>
+        public static void SetVersion(TargetDto target, VersionDTO newVersion, VersionDTO sdkVersion)
+        {
+            PlayerSettings.bundleVersion = $"{target.releaseCycle.GetReleaseInitial()}.{newVersion.VersionFromNow()} Sdk: {sdkVersion.Version()}";
+        }
+
+        /// <summary>
+        /// Set the Application version during play mode.
+        /// </summary>
+        /// <remarks>Do not use this method in build.</remarks>
+        /// <param name="newVersion"></param>
+        /// <param name="sdkVersion"></param>
+        [Conditional("UNITY_EDITOR")]
+        public static void SetVersion(VersionDTO newVersion, VersionDTO sdkVersion)
+        {
+            PlayerSettings.bundleVersion = $"{newVersion.VersionFromNow()} Sdk: {sdkVersion.Version()}";
+        }
+
         #region Conditional settings
 
         /// <summary>

--- a/UMI3D-BROWSER/Assets/Editor/BuildTool/UMI3DBuildTool.cs
+++ b/UMI3D-BROWSER/Assets/Editor/BuildTool/UMI3DBuildTool.cs
@@ -152,6 +152,16 @@ namespace umi3d.browserEditor.BuildTool
             buildView.Set();
         }
 
+        private void OnEnable()
+        {
+            EditorApplication.playModeStateChanged += playModeStateChanged;
+        }
+
+        void OnDisable()
+        {
+            EditorApplication.playModeStateChanged -= playModeStateChanged;
+        }
+
         void ApplyTargetOptions(E_Target target)
         {
             if (Application.isPlaying)
@@ -198,7 +208,7 @@ namespace umi3d.browserEditor.BuildTool
             // Application name. It is the one display in AppData/LocalLow.
             PlayerSettings.productName = BuildToolHelper.GetApplicationName(target);
             // Version number of the application.
-            PlayerSettings.bundleVersion = $"{target.releaseCycle.GetReleaseInitial()}.{versionModel.newVersion.VersionFromNow()} Sdk: {versionModel.sdkVersion.Version()}";
+            BuildToolHelper.SetVersion(target, versionModel.newVersion, versionModel.sdkVersion);
 
             // ------ Conditional compilation settings ------
             // Set the keystore information (Android only).
@@ -241,6 +251,8 @@ namespace umi3d.browserEditor.BuildTool
             // - UMI3D SteamVR (for the steamVR browser).
             // - UMI3D Editor (for the editor).
             PlayerSettings.productName = "UMI3D Editor";
+            // Reset Version to avoir modifying ProjectSettings.asset.
+            PlayerSettings.bundleVersion = "Version will be set dynamically in build or in play mode";
 
             return reportInt;
         }
@@ -258,6 +270,21 @@ namespace umi3d.browserEditor.BuildTool
             {
                 ApplyTargetOptions(target[i].Target);
                 BuildTarget(target[i], i == target.Length - 1);
+            }
+        }
+
+        void playModeStateChanged(PlayModeStateChange state)
+        {
+            switch (state)
+            {
+                case PlayModeStateChange.EnteredPlayMode:
+                    BuildToolHelper.SetVersion(versionModel.newVersion, versionModel.sdkVersion);
+                    break;
+                case PlayModeStateChange.ExitingPlayMode:
+                case PlayModeStateChange.EnteredEditMode:
+                case PlayModeStateChange.ExitingEditMode:
+                default:
+                    break;
             }
         }
     }

--- a/UMI3D-BROWSER/Assets/Editor/BuildTool/ViewsAndViewModels/MainPanel/UMI3DBuildToolMainPanelView.cs
+++ b/UMI3D-BROWSER/Assets/Editor/BuildTool/ViewsAndViewModels/MainPanel/UMI3DBuildToolMainPanelView.cs
@@ -48,6 +48,11 @@ namespace umi3d.browserEditor.BuildTool
             EditorApplication.playModeStateChanged += playModeStateChanged;
         }
 
+        ~UMI3DBuildToolMainPanelView()
+        {
+            EditorApplication.playModeStateChanged -= playModeStateChanged;
+        }
+
         void playModeStateChanged(PlayModeStateChange state)
         {
             if (blockingLayer == null)

--- a/UMI3D-BROWSER/ProjectSettings/ProjectSettings.asset
+++ b/UMI3D-BROWSER/ProjectSettings/ProjectSettings.asset
@@ -136,7 +136,7 @@ PlayerSettings:
   vulkanEnableLateAcquireNextImage: 0
   vulkanEnableCommandBufferRecycling: 1
   loadStoreDebugModeEnabled: 0
-  bundleVersion: 'p.3.6.13.241118 Sdk: b_2.9.0.241106'
+  bundleVersion: Version will be set dynamically in build or in play mode
   preloadedAssets:
   - {fileID: 11400000, guid: eac67687cb7c1d54bbbd3823149b2e20, type: 2}
   metroInputSource: 0


### PR DESCRIPTION
- Add methods to set application version.
- Reset application version after build. 
-> Project settings' application version will not be changed when BuildTool is used.